### PR TITLE
Retain bigrams

### DIFF
--- a/bin/profile
+++ b/bin/profile
@@ -4,18 +4,20 @@ require 'bundler/setup'
 require 'ruby-prof'
 require 'spell'
 
-words = File.read('enable1.txt').split("\n")
-spell = Spell::Spell.new(words)
+5.times do
+  words = File.read('enable1.txt').split("\n")
+  spell = Spell::Spell.new(Hash[words.map { |x| [x, 0] }])
 
-RubyProf.start
+  RubyProf.start
 
-spell.best_match('aligator')
-spell.best_match("sentence")
+  spell.best_match('aligator')
+  spell.best_match('sentence')
 
-result = RubyProf.stop
-printer = RubyProf::GraphHtmlPrinter.new(result)
-branch = `git symbolic-ref --short HEAD`.chomp
-file_name = "profile/#{Time.now.strftime('%Y%m%d%H%M%S%L')}-#{branch}.html"
-printer.print(File.open(file_name, 'w+'))
+  result = RubyProf.stop
+  printer = RubyProf::GraphHtmlPrinter.new(result)
+  branch = `git symbolic-ref --short HEAD`.chomp
+  file_name = "profile/#{Time.now.strftime('%Y%m%d%H%M%S%L')}-#{branch}.html"
+  printer.print(File.open(file_name, 'w+'))
 
-Kernel.system("open #{file_name}") if `uname`.include? 'Darwin'
+  Kernel.system("open #{file_name}") if `uname`.include? 'Darwin'
+end


### PR DESCRIPTION
Retain bigrams and `max_usage`, so they do not need to be calculated for every run. Provided a speedup of ~3 seconds on my machine, for the two word comparisons in the profile test.
